### PR TITLE
add `allow_blank` option for array validations

### DIFF
--- a/lib/type_validator.rb
+++ b/lib/type_validator.rb
@@ -20,6 +20,8 @@ class TypeValidator < ActiveModel::EachValidator
         return send("validate_#{self.class.default_validation}", value, expected)
       end
 
+      return if (options[:array_of] || options[:array_with]) && options[:allow_empty] && value.is_a?(Array) && value.size == 0
+
       if expected = options[:instance_of]; return validate_instance_of(value, expected); end
       if expected = options[:kind_of]    ; return validate_kind_of(value, expected)    ; end
       if expected = options[:is_a]       ; return validate_is_a(value, expected)       ; end

--- a/test/type_validator/by_array_of_test.rb
+++ b/test/type_validator/by_array_of_test.rb
@@ -99,4 +99,36 @@ class TypeValidatorByArrayOfTest < Minitest::Test
       assert_equal('statuses must be an array of: String', err.message)
     end
   end
+
+  # ---
+
+  class Car
+    include ActiveModel::Validations
+
+    attr_reader :problems
+
+    validates :problems, type: { array_of: String }, allow_blank: true
+
+    def initialize(problems:)
+      @problems = problems
+    end
+  end
+
+  def test_the_validation_allow_blank_invalid
+    car = Car.new(problems: 'battery')
+
+    refute_predicate(car, :valid?)
+  end
+
+  def test_the_validation_allow_blank
+    car = Car.new(problems: ['battery'])
+
+    assert_predicate(car, :valid?)
+  end
+
+  def test_the_allow_blank_validation_options
+    person = Car.new(problems: [])
+
+    assert_predicate(person, :valid?)
+  end
 end

--- a/test/type_validator/by_array_with_test.rb
+++ b/test/type_validator/by_array_with_test.rb
@@ -84,4 +84,38 @@ class TypeValidatorByArrayWithTest < Minitest::Test
     err = assert_raises(ArgumentError) { Foo.new(values: [1]).valid? }
     assert_equal('42 must be an array', err.message)
   end
+
+  # ---
+
+  class Car
+    include ActiveModel::Validations
+
+    attr_reader :problems
+
+    validates :problems,
+      type: { array_with: ['battery', 'engine'] },
+      allow_blank: true
+
+    def initialize(problems:)
+      @problems = problems
+    end
+  end
+
+  def test_the_validation_allow_blank_invalid
+    car = Car.new(problems: 'battery')
+
+    refute_predicate(car, :valid?)
+  end
+
+  def test_the_validation_allow_blank
+    car = Car.new(problems: ['battery'])
+
+    assert_predicate(car, :valid?)
+  end
+
+  def test_the_allow_blank_validation_options
+    person = Car.new(problems: [])
+
+    assert_predicate(person, :valid?)
+  end
 end


### PR DESCRIPTION
Adds the `allow_blank: true` option for array validators, to allow empty arrays to be valid arrays.